### PR TITLE
Fix condition to check location in ArtifactProvider

### DIFF
--- a/src/xsoar_client/artifact_provider.py
+++ b/src/xsoar_client/artifact_provider.py
@@ -8,7 +8,7 @@ SUPPORTED_STORES = ["S3"]
 
 class ArtifactProvider:
     def __init__(self, *, location: str = "S3", s3_bucket_name: str | None = None, verify_ssl: str | bool = True) -> None:
-        if location is None:
+        if not location:
             return
         if location not in SUPPORTED_STORES:
             msg = f"Artifact store {location} is not yet implemented."


### PR DESCRIPTION
The config file is stored in JSON, and a location field might be "cleared" in different ways — either set to null or an empty string "".

This change updates the handling logic to treat an empty string as equivalent to a missing/null value.

Might also consider normalising this in the config parser itself (e.g., automatically converting "" → None) to simplify downstream processing.